### PR TITLE
chore: update dependency @testing-library/react to v13

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@fortawesome/fontawesome-svg-core": "6.1.1",
     "@fortawesome/free-solid-svg-icons": "6.1.1",
     "@fortawesome/react-fontawesome": "0.1.18",
-    "@testing-library/react": "12.1.4",
+    "@testing-library/react": "13.0.0",
     "@testing-library/user-event": "13.5.0",
     "axios": "0.26.1",
     "bootstrap": "4.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@fortawesome/fontawesome-svg-core': 6.1.1
   '@fortawesome/free-solid-svg-icons': 6.1.1
   '@fortawesome/react-fontawesome': 0.1.18
-  '@testing-library/react': 12.1.4
+  '@testing-library/react': 13.0.0
   '@testing-library/user-event': 13.5.0
   '@types/jest': 27.4.1
   '@types/node': 14.18.12
@@ -40,7 +40,7 @@ dependencies:
   '@fortawesome/fontawesome-svg-core': 6.1.1
   '@fortawesome/free-solid-svg-icons': 6.1.1
   '@fortawesome/react-fontawesome': 0.1.18_6909f5698ccb6b468185370814560628
-  '@testing-library/react': 12.1.4_react-dom@17.0.2+react@17.0.2
+  '@testing-library/react': 13.0.0_react-dom@17.0.2+react@17.0.2
   '@testing-library/user-event': 13.5.0
   axios: 0.26.1
   bootstrap: 4.6.1
@@ -2567,12 +2567,12 @@ packages:
       pretty-format: 27.5.1
     dev: false
 
-  /@testing-library/react/12.1.4_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-jiPKOm7vyUw311Hn/HlNQ9P8/lHNtArAx0PisXyFixDDvfl8DbD6EUdbshK5eqauvBSvzZd19itqQ9j3nferJA==}
+  /@testing-library/react/13.0.0_react-dom@17.0.2+react@17.0.2:
+    resolution: {integrity: sha512-p0lYA1M7uoEmk2LnCbZLGmHJHyH59sAaZVXChTXlyhV/PRW9LoIh4mdf7tiXsO8BoNG+vN8UnFJff1hbZeXv+w==}
     engines: {node: '>=12'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.14.8
       '@testing-library/dom': 8.5.0


### PR DESCRIPTION
In GitLab by @bot-4s1 on Mar 31, 2022, 09:04

This MR contains the following updates:

| Package | Type | Update | Change |
|---|---|---|---|
| [@testing-library/react](https://github.com/testing-library/react-testing-library) | dependencies | major | [`12.1.4` -> `13.0.0`](https://renovatebot.com/diffs/npm/@testing-library%2freact/12.1.4/13.0.0) |

---

### Release Notes

<details>
<summary>testing-library/react-testing-library</summary>

### [`v13.0.0`](https://github.com/testing-library/react-testing-library/releases/v13.0.0)

[Compare Source](https://github.com/testing-library/react-testing-library/compare/v12.1.4...v13.0.0)

##### Features

-   Add support for React 18 ([#&#8203;1031](https://github.com/testing-library/react-testing-library/issues/1031)) ([ccd8a0d](https://github.com/testing-library/react-testing-library/commit/ccd8a0d97dd9da0a420f2cf012a24d414d1646ed))

##### BREAKING CHANGES

-   Drop support for React 17 and earlier. We'll use the new [`createRoot` API](https://github.com/reactwg/react-18/discussions/5) by default which comes with a set of [changes while also enabling support for concurrent features](https://github.com/reactwg/react-18/discussions/4).
    To opt-out of this change you can use `render(ui, { legacyRoot: true } )`. But be aware that the legacy root API is deprecated in React 18 and its usage will trigger console warnings.

</details>

---

### Configuration

📅 **Schedule**: At any time (no schedule defined).

🚦 **Automerge**: Disabled by config. Please merge this manually once you are satisfied.

♻ **Rebasing**: Whenever MR becomes conflicted, or you tick the rebase/retry checkbox.

🔕 **Ignore**: Close this MR and you won't be reminded about this update again.

---

 - [ ] <!-- rebase-check -->If you want to rebase/retry this MR, click this checkbox.

---

This MR has been generated by [Renovate Bot](https://github.com/renovatebot/renovate).